### PR TITLE
feat: Force TREError errors parameter to parse as String

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageBuilder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageBuilder.scala
@@ -118,7 +118,7 @@ sealed trait RequestStatus {
 
 case object Received extends RequestStatus {
   val header = "Request Received"
-  val iconName = "hourglass_with_flowing_sand"
+  val iconName = "hourglass_flowing_sand"
 }
 
 case object Completed extends RequestStatus {

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -14,6 +14,16 @@ object MessageParsingUtils {
   implicit val courtDocumentPackageAvailableStatusDecoder: Decoder[CDPAStatus.Value] = Decoder.decodeEnumeration(CDPAStatus)
   implicit val treErrorStatusDecoder: Decoder[TEStatus.Value] = Decoder.decodeEnumeration(TEStatus)
 
+  implicit val decodeTreParameters: Decoder[Parameters] = (c: HCursor) => for {
+    status <- c.downField("status").as[TEStatus.Value]
+    originator <- c.downField("originator").as[Option[String]]
+    reference <- c.downField("reference").as[String]
+    errors = {
+      val errorsCursor = c.downField("errors")
+      errorsCursor.as[Option[String]].fold(_ => errorsCursor.focus.map(_.toString), identity)
+    }
+  } yield Parameters(status, originator, reference, errors)
+  
   def parseGenericMessage(message: String): GenericMessage =
     parser.decode[GenericMessage](message).fold(error => throw new RuntimeException(error), identity)
 


### PR DESCRIPTION
Occasionally the errors field comes out of the step functions as json- in this case, we just want to publish the json value as a string.